### PR TITLE
Bump ocserv 1.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.12.3
 
 LABEL maintainer="Amin Vakil <info@aminvakil.com>"
 
-ENV OC_VERSION=1.1.1
+ENV OC_VERSION=1.1.2
 
 RUN apk add --no-cache bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN set -x \
 	&& sed -i 's/^no-route/#no-route/' /etc/ocserv/ocserv.conf \
 	&& sed -i '/\[vhost:www.example.com\]/,$d' /etc/ocserv/ocserv.conf \
 	&& sed -i '/^cookie-timeout = /{s/300/3600/}' /etc/ocserv/ocserv.conf \
+	&& sed -i 's/^isolate-workers/#isolate-workers/' /etc/ocserv/ocserv.conf \
 	&& cat /tmp/routes.txt >> /etc/ocserv/ocserv.conf \
 	&& rm -rf /tmp/routes.txt
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 docker-ocserv is an OpenConnect VPN Server boxed in a Docker image built by [Tommy Lau](mailto:tommy@gen-new.com) currently maintained by [Amin Vakil](mailto:info@aminvakil.com).
 
+## Update on Dec 30, 2020
+
+Upgrade alpine to 3.12.3 and ocserv to 1.1.2.
+
+###**Important Note**:
+
+`isolate-workers = true` should be disabled in ocserv.conf, otherwise clients keep disconnecting after a while.
+
+This has been set by default on the new docker images, but you should change your current containers with this command yourself:
+
+```bash
+docker exec YOUR_CONTAINER_NAME sed -i 's/^isolate-workers/#isolate-workers/' /etc/ocserv/ocserv.conf
+```
 ## Update on Sep 05, 2020
 
 Migrate from Docker Hub to Quay as they're going to put limit for those who aren't willing to give them money.


### PR DESCRIPTION
`isolate-workers` should be disabled for this version to work, otherwise it keeps disconnecting users.