### PR TITLE
Add network to iptables command

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -21,7 +21,7 @@ jobs:
           HADOLINT_VERSION: 2.12.0
 
       - name: Run hadolint.
-        run: hadolint --ignore DL3003 --ignore DL3018 --ignore DL3019 --ignore SC2016 Dockerfile
+        run: hadolint --ignore DL3003 --ignore DL3018 --ignore DL3019 Dockerfile
 
   build:
     name: Build and test docker

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -21,7 +21,7 @@ jobs:
           HADOLINT_VERSION: 2.12.0
 
       - name: Run hadolint.
-        run: hadolint --ignore DL3003 --ignore DL3018 --ignore DL3019 Dockerfile
+        run: hadolint --ignore DL3003 --ignore DL3018 --ignore DL3019 --ignore SC2016 Dockerfile
 
   build:
     name: Build and test docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN set -x \
 	    -e 's/\.\.\/tests/\/etc\/ocserv/' \
 	    -e 's/#\(compression.*\)/\1/' \
 	    -e '/^ipv4-network = /{s/192.168.1.0/${OC_IPV4_NETWORK}/}' \
-	    -e '/^ipv4-netmask = /{s/255.255.255.0/${OC_IPV4_NETMASK}}/}' \
+	    -e '/^ipv4-netmask = /{s/255.255.255.0/${OC_IPV4_NETMASK}/}' \
 	    -e 's/192.168.1.2/8.8.8.8/' \
 	    -e 's/^route/#route/' \
 	    -e 's/^no-route/#no-route/' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN buildDeps=( \
 
 # Setup config
 COPY routes.txt /tmp/
+
+# hadolint ignore=SC2016
 RUN set -x \
 	&& sed -e 's/\.\/sample\.passwd/\/etc\/ocserv\/ocpasswd/' \
 	    -e 's/\(max-same-clients = \)2/\110/' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM alpine:3.20.0
 LABEL maintainer="Amin Vakil <info@aminvakil.com>, Dmitry Romashov <dmitry@romashov.tech>"
 
 ENV OC_VERSION=1.3.0
+ENV OC_IPV4_NETWORK="192.168.99.0"
+ENV OC_IPV4_NETMASK="255.255.255.0"
 
 RUN apk add --no-cache bash
 
@@ -45,26 +47,28 @@ RUN buildDeps=( \
 			| sort -u \
 		)" \
 	&& readarray runDepsArr <<< "$runDeps" \
-	&& apk add --virtual .run-deps "${runDepsArr[@]}" gnutls-utils iptables libnl3 readline libseccomp-dev lz4-dev \
+	&& apk add --virtual .run-deps "${runDepsArr[@]}" gnutls-utils iptables libnl3 readline libseccomp-dev lz4-dev gettext-envsubst \
 	&& apk del .build-deps \
 	&& rm -rf /var/cache/apk/*
 
 # Setup config
 COPY routes.txt /tmp/
 RUN set -x \
-	&& sed -i 's/\.\/sample\.passwd/\/etc\/ocserv\/ocpasswd/' /etc/ocserv/ocserv.conf \
-	&& sed -i 's/\(max-same-clients = \)2/\110/' /etc/ocserv/ocserv.conf \
-	&& sed -i 's/\.\.\/tests/\/etc\/ocserv/' /etc/ocserv/ocserv.conf \
-	&& sed -i 's/#\(compression.*\)/\1/' /etc/ocserv/ocserv.conf \
-	&& sed -i '/^ipv4-network = /{s/192.168.1.0/192.168.99.0/}' /etc/ocserv/ocserv.conf \
-	&& sed -i 's/192.168.1.2/8.8.8.8/' /etc/ocserv/ocserv.conf \
-	&& sed -i 's/^route/#route/' /etc/ocserv/ocserv.conf \
-	&& sed -i 's/^no-route/#no-route/' /etc/ocserv/ocserv.conf \
-	&& sed -i '/\[vhost:www.example.com\]/,$d' /etc/ocserv/ocserv.conf \
-	&& sed -i '/^cookie-timeout = /{s/300/3600/}' /etc/ocserv/ocserv.conf \
-	&& sed -i 's/^isolate-workers/#isolate-workers/' /etc/ocserv/ocserv.conf \
-	&& cat /tmp/routes.txt >> /etc/ocserv/ocserv.conf \
-	&& rm -rf /tmp/routes.txt
+	&& sed -e 's/\.\/sample\.passwd/\/etc\/ocserv\/ocpasswd/' \
+	    -e 's/\(max-same-clients = \)2/\110/' \
+	    -e 's/\.\.\/tests/\/etc\/ocserv/' \
+	    -e 's/#\(compression.*\)/\1/' \
+	    -e '/^ipv4-network = /{s/192.168.1.0/${OC_IPV4_NETWORK}/}' \
+	    -e '/^ipv4-netmask = /{s/255.255.255.0/${OC_IPV4_NETMASK}}/}' \
+	    -e 's/192.168.1.2/8.8.8.8/' \
+	    -e 's/^route/#route/' \
+	    -e 's/^no-route/#no-route/' \
+	    -e '/\[vhost:www.example.com\]/,$d' \
+	    -e '/^cookie-timeout = /{s/300/3600/}' \
+	    -e 's/^isolate-workers/#isolate-workers/' /etc/ocserv/ocserv.conf > /tmp/ocserv.conf \
+	&& cat /tmp/routes.txt >> /tmp/ocserv.conf \
+	&& envsubst < /tmp/ocserv.conf > /etc/ocserv/ocserv.conf \
+	&& rm -f /tmp/ocserv.conf
 
 WORKDIR /etc/ocserv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,7 @@ RUN set -x \
 	    -e '/\[vhost:www.example.com\]/,$d' \
 	    -e '/^cookie-timeout = /{s/300/3600/}' \
 	    -e 's/^isolate-workers/#isolate-workers/' /etc/ocserv/ocserv.conf > /tmp/ocserv.conf \
-	&& cat /tmp/routes.txt >> /tmp/ocserv.conf \
-	&& envsubst < /tmp/ocserv.conf > /etc/ocserv/ocserv.conf \
-	&& rm -f /tmp/ocserv.conf
+	&& cat /tmp/routes.txt >> /tmp/ocserv.conf
 
 WORKDIR /etc/ocserv
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -71,5 +71,8 @@ mkdir -p /dev/net
 mknod /dev/net/tun c 10 200
 chmod 600 /dev/net/tun
 
+# Update config
+envsubst < /tmp/ocserv.conf > /etc/ocserv/ocserv.conf
+
 # Run OpennConnect Server
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -63,7 +63,7 @@ fi
 sysctl -w net.ipv4.ip_forward=1
 
 # Enable NAT forwarding
-iptables -t nat -A POSTROUTING -j MASQUERADE
+iptables -t nat -A POSTROUTING -j MASQUERADE -s 192.168.99.0/24
 iptables -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
 # Enable TUN device

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -63,7 +63,7 @@ fi
 sysctl -w net.ipv4.ip_forward=1
 
 # Enable NAT forwarding
-iptables -t nat -A POSTROUTING -j MASQUERADE -s 192.168.99.0/24
+iptables -t nat -A POSTROUTING -j MASQUERADE -s "${OC_IPV4_NETWORK}"/"${OC_IPV4_NETMASK}"
 iptables -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
 # Enable TUN device

--- a/routes.txt
+++ b/routes.txt
@@ -1,5 +1,5 @@
 route=default
-route = 192.168.99.0/255.255.255.0
+route = ${OC_IPV4_NETWORK}/${OC_IPV4_NETMASK}
 no-route = 192.168.0.0/255.255.0.0
 no-route = 10.0.0.0/255.0.0.0
 no-route = 172.16.0.0/255.240.0.0


### PR DESCRIPTION
When running in some environments, e.g. Kubernetes, the iptables command can cause the CNI to have issues. In my case, both calico-typha and calico-node began to fail health checks once the original iptables command was executed. Adding the ocserv network to the command allowed it to work as expected.