### PR TITLE
Add network to iptables command - take 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN buildDeps=( \
 		readline-dev \
 		tar \
 		xz \
-	); \
+	) \
 	&& apk add --update --virtual .build-deps "${buildDeps[@]}" \
 	&& curl -SL --connect-timeout 8 --max-time 120 --retry 128 --retry-delay 5 "ftp://ftp.infradead.org/pub/ocserv/ocserv-$OC_VERSION.tar.xz" -o ocserv.tar.xz \
 	&& mkdir -p /usr/src/ocserv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN buildDeps=( \
 COPY routes.txt /tmp/
 
 # hadolint ignore=SC2016
-RUN mv /etc/ocserv/ocserv.conf /etc/ocserv/ocserv-default.conf \
+RUN mv /etc/ocserv/ocserv.conf /tmp/ocserv-default.conf \
 	&& sed -e 's/\.\/sample\.passwd/\/etc\/ocserv\/ocpasswd/' \
 	    -e 's/\(max-same-clients = \)2/\110/' \
 	    -e 's/\.\.\/tests/\/etc\/ocserv/' \
@@ -66,7 +66,7 @@ RUN mv /etc/ocserv/ocserv.conf /etc/ocserv/ocserv-default.conf \
 	    -e 's/^no-route/#no-route/' \
 	    -e '/\[vhost:www.example.com\]/,$d' \
 	    -e '/^cookie-timeout = /{s/300/3600/}' \
-	    -e 's/^isolate-workers/#isolate-workers/' /etc/ocserv/ocserv-default.conf > /tmp/ocserv.conf \
+	    -e 's/^isolate-workers/#isolate-workers/' /tmp/ocserv-default.conf > /tmp/ocserv.conf \
 	&& cat /tmp/routes.txt >> /tmp/ocserv.conf
 
 WORKDIR /etc/ocserv

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV OC_IPV4_NETMASK="255.255.255.0"
 
 RUN apk add --no-cache bash
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 RUN buildDeps=( \
 		curl \
@@ -26,7 +26,6 @@ RUN buildDeps=( \
 		tar \
 		xz \
 	); \
-	set -x \
 	&& apk add --update --virtual .build-deps "${buildDeps[@]}" \
 	&& curl -SL --connect-timeout 8 --max-time 120 --retry 128 --retry-delay 5 "ftp://ftp.infradead.org/pub/ocserv/ocserv-$OC_VERSION.tar.xz" -o ocserv.tar.xz \
 	&& mkdir -p /usr/src/ocserv \
@@ -55,7 +54,7 @@ RUN buildDeps=( \
 COPY routes.txt /tmp/
 
 # hadolint ignore=SC2016
-RUN set -x \
+RUN mv /etc/ocserv/ocserv.conf /etc/ocserv/ocserv-default.conf \
 	&& sed -e 's/\.\/sample\.passwd/\/etc\/ocserv\/ocpasswd/' \
 	    -e 's/\(max-same-clients = \)2/\110/' \
 	    -e 's/\.\.\/tests/\/etc\/ocserv/' \
@@ -67,7 +66,7 @@ RUN set -x \
 	    -e 's/^no-route/#no-route/' \
 	    -e '/\[vhost:www.example.com\]/,$d' \
 	    -e '/^cookie-timeout = /{s/300/3600/}' \
-	    -e 's/^isolate-workers/#isolate-workers/' /etc/ocserv/ocserv.conf > /tmp/ocserv.conf \
+	    -e 's/^isolate-workers/#isolate-workers/' /etc/ocserv/ocserv-default.conf > /tmp/ocserv.conf \
 	&& cat /tmp/routes.txt >> /tmp/ocserv.conf
 
 WORKDIR /etc/ocserv

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN buildDeps=( \
 	&& make \
 	&& make install \
 	&& mkdir -p /etc/ocserv \
-	&& cp /usr/src/ocserv/doc/sample.config /etc/ocserv/ocserv.conf \
+	&& cp /usr/src/ocserv/doc/sample.config /tmp/ocserv-default.conf \
 	&& cd / \
 	&& rm -fr /usr/src/ocserv \
 	&& runDeps="$( \
@@ -54,8 +54,7 @@ RUN buildDeps=( \
 COPY routes.txt /tmp/
 
 # hadolint ignore=SC2016
-RUN mv /etc/ocserv/ocserv.conf /tmp/ocserv-default.conf \
-	&& sed -e 's/\.\/sample\.passwd/\/etc\/ocserv\/ocpasswd/' \
+RUN sed -e 's/\.\/sample\.passwd/\/etc\/ocserv\/ocpasswd/' \
 	    -e 's/\(max-same-clients = \)2/\110/' \
 	    -e 's/\.\.\/tests/\/etc\/ocserv/' \
 	    -e 's/#\(compression.*\)/\1/' \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -73,6 +73,7 @@ chmod 600 /dev/net/tun
 
 # Update config
 if [ ! -f /etc/ocserv/ocserv.conf ]; then
+	echo "Creating ocserv config '/etc/ocserv/ocserv.conf'"
 	envsubst < /tmp/ocserv.conf > /etc/ocserv/ocserv.conf
 fi
 


### PR DESCRIPTION
This PR is a re-spin of https://github.com/aminvakil/docker-ocserv/pull/72, but is updated to ensure that if an end user provides a config file at `/etc/ocserv/ocserv.conf`, it is not overwritten. This allows users to mount in their config files or perform other out-of-band changes without them being clobbered.