### PR TITLE
Redirect logs to stderr instead of syslog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,4 @@ COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 443
-CMD ["ocserv", "-c", "/etc/ocserv/ocserv.conf", "-f"]
+CMD ["ocserv", "-c", "/etc/ocserv/ocserv.conf", "-f", "-e"]


### PR DESCRIPTION
When running this container, there are no logs present except the initial startup logs.
User connections are not being logged.

This is because syslog is being used which is not exposed in the container it self:

```
   -e, --log-stderr           Log to stderr
   -s, --syslog               Log to syslog (default)
```

Add flag to log to stderr, this will make the `docker logs ocserv` show who is connecting and when.
